### PR TITLE
Created upload handler

### DIFF
--- a/src/main/java/edu/ucla/library/validation/handlers/UploadHandler.java
+++ b/src/main/java/edu/ucla/library/validation/handlers/UploadHandler.java
@@ -1,0 +1,59 @@
+
+package edu.ucla.library.validation.handlers;
+
+import static edu.ucla.library.validation.MediaType.APPLICATION_JSON;
+
+import info.freelibrary.util.HTTP;
+import java.util.List;
+
+import edu.ucla.library.validation.JsonKeys;
+
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.buffer.Buffer;
+
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.FileUpload;
+
+/**
+ * A handler that processes status information requests.
+ */
+public class UploadHandler implements Handler<RoutingContext> {
+
+    /** The handler's copy of the Vert.x instance. */
+    private final Vertx myVertx;
+
+    /**
+     * Creates a handler that returns a status response.
+     *
+     * @param aVertx A Vert.x instance
+     */
+    public UploadHandler(final Vertx aVertx) {
+        myVertx = aVertx;
+    }
+
+    @Override
+    public void handle(final RoutingContext aContext) {
+        List<FileUpload> fileUploads = aContext.fileUploads();
+        for (FileUpload fileUpload : fileUploads) {
+            String uploadedFileName = fileUpload.fileName();
+            Buffer uploadedFile = myVertx.fileSystem().readFileBlocking(fileUpload.uploadedFileName());
+            String fileContents = uploadedFile.toString();
+
+            // Send the contents back to the browser
+            aContext.response().end(fileContents);
+        }
+
+    }
+
+    /**
+     * Gets the Vert.x instance associated with this handler.
+     *
+     * @return The Vert.x instance associated with this handler
+     */
+    public Vertx getVertx() {
+        return myVertx;
+    }
+}

--- a/src/main/java/edu/ucla/library/validation/verticles/MainVerticle.java
+++ b/src/main/java/edu/ucla/library/validation/verticles/MainVerticle.java
@@ -12,9 +12,11 @@ import edu.ucla.library.validation.Config;
 import edu.ucla.library.validation.MessageCodes;
 import edu.ucla.library.validation.Op;
 import edu.ucla.library.validation.handlers.StatusHandler;
+import edu.ucla.library.validation.handlers.UploadHandler;
 
 import io.vertx.ext.web.handler.StaticHandler;
 import io.vertx.ext.web.Router;
+import io.vertx.ext.web.handler.BodyHandler;
 
 import io.vertx.config.ConfigRetriever;
 import io.vertx.core.AbstractVerticle;
@@ -69,12 +71,13 @@ public class MainVerticle extends AbstractVerticle {
         RouterBuilder.create(vertx, getRouterSpec()).onFailure(aPromise::fail).onSuccess(routeBuilder -> {
 
             final HttpServerOptions serverOptions = new HttpServerOptions().setPort(port).setHost(host);
-
             // Associate handlers with operation IDs from the application's OpenAPI specification
             routeBuilder.operation(Op.GET_STATUS.id()).handler(new StatusHandler(getVertx()));
 
             final Router router = routeBuilder.createRouter();
 
+            router.route().handler(BodyHandler.create().setUploadsDirectory("uploads"));
+            router.post("/upload").handler(new UploadHandler(getVertx()));
             router.route("/ui/*").handler(StaticHandler.create("src/main/webroot"));
 
             myServer = getVertx().createHttpServer(serverOptions).requestHandler(router);


### PR DESCRIPTION
Created a handler for the upload form which reads and displays the contents of the uploaded file to the browser. The endpoint hit is /upload. Currently it works using router (instead of routeBuilder and operation) and need to update the OpenAPI document to include the /upload endpoint.