### PR TITLE
[SERV-1186] Add ARK check and GetHeader function

### DIFF
--- a/csvutils/location.go
+++ b/csvutils/location.go
@@ -1,7 +1,10 @@
 // Package csvutils has structures and utilities useful for working with CSVs.
 package csvutils
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // Location represents an index-based location in a CSV file.
 //
@@ -26,4 +29,21 @@ func IsValidLocation(location Location, csvData [][]string) error {
 
 	// Supplied Location is valid for the supplied csvData
 	return nil
+}
+
+// GetHeader returns the header within the first row given the index
+func GetHeader(location Location, csvData [][]string) (string, error) {
+	if err := IsValidLocation(location, csvData); err != nil {
+		return "", err
+	}
+
+	index := location.ColIndex
+
+	// Ensure the first row exists
+	headers := csvData[0]
+	if len(headers) == 0 {
+		return "", errors.New("the first row of csvData is empty")
+	}
+
+	return headers[index], nil
 }

--- a/csvutils/location_test.go
+++ b/csvutils/location_test.go
@@ -5,6 +5,8 @@ package csvutils
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestIsValidLocation tests whether a supplied csv.Location is valid considering the supplied csvData.
@@ -36,6 +38,75 @@ func TestIsValidLocation(t *testing.T) {
 				// Shouldn't have an err on true shouldPass results and should have an err on false shouldPass results
 				t.Errorf("IsValidLocation(%v, csvData); found error: %v, expected error: %v", test.location,
 					!test.shouldPass, test.shouldPass)
+			}
+		})
+	}
+}
+
+// TestGetHeader verifys that GetHeader returns the expected header in the first row
+func TestGetHeader(t *testing.T) {
+	tests := []struct {
+		name        string
+		location    Location
+		csvData     [][]string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:     "Valid header retrieval",
+			location: Location{ColIndex: 1},
+			csvData: [][]string{
+				{"ID", "Name", "Age"},
+				{"1", "Alice", "30"},
+			},
+			expected:    "Name",
+			expectError: false,
+		},
+		{
+			name:     "First column retrieval",
+			location: Location{ColIndex: 0},
+			csvData: [][]string{
+				{"ID", "Name", "Age"},
+				{"1", "Alice", "30"},
+			},
+			expected:    "ID",
+			expectError: false,
+		},
+		{
+			name:     "Out of bounds column index",
+			location: Location{ColIndex: 3},
+			csvData: [][]string{
+				{"ID", "Name", "Age"},
+				{"1", "Alice", "30"},
+			},
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Empty first row",
+			location:    Location{ColIndex: 0},
+			csvData:     [][]string{{}, {"1", "Alice", "30"}},
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "Empty CSV data",
+			location:    Location{ColIndex: 0},
+			csvData:     [][]string{},
+			expected:    "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := GetHeader(tt.location, tt.csvData)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
 			}
 		})
 	}

--- a/validation/checks/ark_check.go
+++ b/validation/checks/ark_check.go
@@ -84,9 +84,7 @@ func verifyArk(ark string, profile string) error {
 	// Extract NAAN and ObjectIdentifier for further validation
 	naan := naanMatch[1]
 	objectID := strings.TrimPrefix(arkBody, naan)
-	if strings.HasPrefix(objectID, "/") {
-		objectID = strings.TrimPrefix(objectID, "/")
-	}
+	objectID = strings.TrimPrefix(objectID, "/")
 	// Additional validation if the profile is "default"
 	if profile == "default" && naan != "21198" {
 		errs = multierr.Combine(errs, defaultProErr)

--- a/validation/checks/ark_check.go
+++ b/validation/checks/ark_check.go
@@ -1,0 +1,106 @@
+package checks
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+
+	csv "github.com/UCLALibrary/validation-service/csvutils"
+	"github.com/UCLALibrary/validation-service/validation/config"
+	"go.uber.org/multierr"
+)
+
+var ITEMARK = "Item ARK"
+var PARENTARK = "Parent ARK"
+
+// Error messages
+var (
+	profileErr        = errors.New("supplied Profiles cannot be nil")
+	noPrefixErr       = errors.New("ARK must start with 'ark:/'")
+	naanTooShortErr   = errors.New("NAAN must be at least 5 digits long")
+	defaultProErr     = errors.New("For the 'default' profile, the NAAN must be '21198'")
+	noObjIdentErr     = errors.New("The ARK must contain an object identifier")
+	invalidObjIdenErr = errors.New("The object identifier and qualifier is not valid")
+)
+
+// ArkCheck type is a validator that checks for a valid Ark
+//
+// It implements the Validator interface and returns an error on failure to validate.
+type ArkCheck struct{}
+
+// NewArkCheck checks that an Ark is valid
+func (check *ArkCheck) NewArkCheck(profiles *config.Profiles) (*ArkCheck, error) {
+	if profiles == nil {
+		return nil, profileErr
+	}
+
+	return &ArkCheck{}, nil
+}
+
+// Validate checks a data cell has a valid Ark in it.
+//
+// If the supplied “profile” is “default” the institutional prefix in the ARK must be 21198
+func (check *ArkCheck) Validate(profile string, location csv.Location, csvData [][]string) error {
+	if err := csv.IsValidLocation(location, csvData); err != nil {
+		return err
+	}
+
+	// find the header and determine if it matches an ark header
+	header, err := csv.GetHeader(location, csvData)
+
+	if err != nil {
+		return err
+	}
+
+	if header != ITEMARK && header != PARENTARK {
+		return nil
+	}
+
+	value := csvData[location.RowIndex][location.ColIndex]
+
+	// Check if the CSV data cell has a valid Ark
+	return verifyArk(value, profile)
+}
+
+// VerifyARK validates if the given string is a valid ARK
+func verifyArk(ark string, profile string) error {
+	var errs error
+
+	// Ensure the ARK starts with "ark:/"
+	if !strings.HasPrefix(ark, "ark:/") {
+		errs = multierr.Combine(errs, noPrefixErr)
+		return errs // Early return since the rest of validation depends on this
+	}
+
+	// Remove "ark:/" for further validation
+	arkBody := strings.TrimPrefix(ark, "ark:/")
+
+	// Validate the NAAN separately
+	naanRegex := regexp.MustCompile(`^(\d+)`)
+	naanMatch := naanRegex.FindStringSubmatch(arkBody)
+	if naanMatch == nil || len(naanMatch[1]) < 5 {
+		errs = multierr.Combine(errs, naanTooShortErr)
+	}
+	// Extract NAAN and ObjectIdentifier for further validation
+	naan := naanMatch[1]
+	objectID := strings.TrimPrefix(arkBody, naan)
+	if strings.HasPrefix(objectID, "/") {
+		objectID = strings.TrimPrefix(objectID, "/")
+	}
+	// Additional validation if the profile is "default"
+	if profile == "default" && naan != "21198" {
+		errs = multierr.Combine(errs, defaultProErr)
+	}
+
+	if objectID == "" {
+		errs = multierr.Combine(errs, noObjIdentErr)
+		return errs
+	}
+	// Validate the remaining ARK structure (ObjectIdentifier + Qualifier)
+	arkRegex := regexp.MustCompile(`^([\w\-./]+)(\?.*)?$`)
+	if !arkRegex.MatchString(objectID) {
+		errs = multierr.Combine(errs, invalidObjIdenErr)
+	}
+
+	return errs
+}

--- a/validation/checks/ark_check.go
+++ b/validation/checks/ark_check.go
@@ -2,6 +2,7 @@ package checks
 
 import (
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -23,24 +24,24 @@ var (
 	invalidObjIdenErr = errors.New("The object identifier and qualifier is not valid")
 )
 
-// ArkCheck type is a validator that checks for a valid Ark
+// ARKCheck type is a validator that checks for a valid Ark
 //
 // It implements the Validator interface and returns an error on failure to validate.
-type ArkCheck struct{}
+type ARKCheck struct{}
 
-// NewArkCheck checks that an Ark is valid
-func (check *ArkCheck) NewArkCheck(profiles *config.Profiles) (*ArkCheck, error) {
+// NewARKCheck checks that an Ark is valid
+func (check *ARKCheck) NewARKCheck(profiles *config.Profiles) (*ARKCheck, error) {
 	if profiles == nil {
 		return nil, profileErr
 	}
 
-	return &ArkCheck{}, nil
+	return &ARKCheck{}, nil
 }
 
 // Validate checks a data cell has a valid Ark in it.
 //
 // If the supplied “profile” is “default” the institutional prefix in the ARK must be 21198
-func (check *ArkCheck) Validate(profile string, location csv.Location, csvData [][]string) error {
+func (check *ARKCheck) Validate(profile string, location csv.Location, csvData [][]string) error {
 	if err := csv.IsValidLocation(location, csvData); err != nil {
 		return err
 	}
@@ -59,7 +60,12 @@ func (check *ArkCheck) Validate(profile string, location csv.Location, csvData [
 	value := csvData[location.RowIndex][location.ColIndex]
 
 	// Check if the CSV data cell has a valid Ark
-	return verifyArk(value, profile)
+	if err := verifyArk(value, profile); err != nil {
+		return fmt.Errorf("ARK validation failed at (row: %d, column: %d) [profile: %s]: %w",
+			location.RowIndex, location.ColIndex, profile, err)
+	}
+
+	return nil
 }
 
 // VerifyARK validates if the given string is a valid ARK

--- a/validation/checks/ark_check_test.go
+++ b/validation/checks/ark_check_test.go
@@ -1,5 +1,3 @@
-//go:build unit
-
 package checks
 
 import (
@@ -44,7 +42,7 @@ func TestVerifyArk(t *testing.T) {
 			expectedErr: noPrefixErr,
 		},
 		{
-			name:        "Invalid ARK structure",
+			name:        "Invalid ARK structure no object identifier",
 			ark:         "ark:/12345",
 			profile:     "random",
 			expectError: true,

--- a/validation/checks/ark_check_test.go
+++ b/validation/checks/ark_check_test.go
@@ -1,0 +1,96 @@
+//go:build unit
+
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+)
+
+// TestVerifyArk checks if verifyArk throws the correct errors when given incorrect ARKs
+func TestVerifyArk(t *testing.T) {
+	tests := []struct {
+		name        string
+		ark         string
+		profile     string
+		expectError bool
+		expectedErr error
+	}{
+		{
+			name:        "Valid ARK with default profile",
+			ark:         "ark:/21198/xyz123",
+			profile:     "default",
+			expectError: false,
+		},
+		{
+			name:        "Valid ARK with qualifier",
+			ark:         "ark:/12345/xyz123?version=2",
+			profile:     "custom",
+			expectError: false,
+		},
+		{
+			name:        "Valid ARK with non-default profile",
+			ark:         "ark:/12345/abc456",
+			profile:     "custom",
+			expectError: false,
+		},
+		{
+			name:        "Invalid ARK - missing ark:/ prefix",
+			ark:         "12345/xyz123",
+			profile:     "default",
+			expectError: true,
+			expectedErr: noPrefixErr,
+		},
+		{
+			name:        "Invalid ARK structure",
+			ark:         "ark:/12345",
+			profile:     "random",
+			expectError: true,
+			expectedErr: noObjIdentErr,
+		},
+		{
+			name:        "Invalid NAAN - less than 5 digits",
+			ark:         "ark:/123/",
+			profile:     "default",
+			expectError: true,
+			expectedErr: multierr.Combine(naanTooShortErr, defaultProErr, noObjIdentErr),
+		},
+		{
+			name:        "Invalid NAAN for default profile",
+			ark:         "ark:/12345/xyz123",
+			profile:     "default",
+			expectError: true,
+			expectedErr: defaultProErr,
+		},
+		{
+			name:        "Invalid object identifier",
+			ark:         "ark:/12345/my identifier",
+			profile:     "random",
+			expectError: true,
+			expectedErr: invalidObjIdenErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyArk(tt.ark, tt.profile)
+
+			if tt.expectError {
+				assert.Error(t, err)
+
+				// If expectedErr is a combined error, check each error individually
+				if merr, ok := tt.expectedErr.(interface{ Unwrap() []error }); ok {
+					for _, expectedErr := range merr.Unwrap() {
+						assert.ErrorIs(t, err, expectedErr, "expected error: %v", expectedErr)
+					}
+				} else {
+					assert.ErrorIs(t, err, tt.expectedErr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/validation/registry.go
+++ b/validation/registry.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+
 	"github.com/UCLALibrary/validation-service/validation/checks"
 	"github.com/UCLALibrary/validation-service/validation/config"
 	"go.uber.org/zap"


### PR DESCRIPTION
- Add testing and general validator for ARK
- The GetHeader function helps location the header of a given column. It is a helper function that can be used in all validators 
- This PR does not include the addition of ARK_Check to the registry.go due to issues with testing