### PR TITLE
[SERV-1232] Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,27 +14,21 @@
       "rangeStrategy": "bump"
     },
     {
-      "matchManagers": ["gomod"],
-      "matchDepNames": ["go"],
-      "automerge": false
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
     },
     {
       "matchManagers": ["gomod"],
-      "groupName": "Go updates",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "groupName": "Go updates"
     },
     {
       "matchManagers": ["dockerfile"],
-      "groupName": "Docker updates",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "groupName": "Docker updates"
     },
     {
       "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions updates",
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true
+      "groupName": "GitHub Actions updates"
     }
-  ]
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
This allows automerging which is not currently configurable with bypassing rulesets, but it is an option that we would like to enable in the future