### PR TITLE
[SERV-1233] Final cleanup of deployment GAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,8 +89,7 @@ jobs:
         with:
           cmd: |
             yq '.image.tag = "${{ github.event.release.tag_name }}"' 'pkg/helm/test-validator.yaml' |
-            yq '.configmap.data.VERSION = "${{ github.event.release.tag_name }}"' |
-            yq e 'with(.configmap.data.VERSION; .style = "double")' > test-validator-new.yaml
+            yq e 'with(.image.tag; .style = "double")' > test-validator-new.yaml
 
       - name: Commit test version update
         run: |
@@ -124,8 +123,7 @@ jobs:
         with:
           cmd: |
             yq '.image.tag = "${{ github.event.release.tag_name }}"' 'pkg/helm/prod-validator.yaml' |
-            yq '.configmap.data.VERSION = "${{ github.event.release.tag_name }}"' |
-            yq e 'with(.configmap.data.VERSION; .style = "double")' > prod-validator-new.yaml
+            yq e 'with(.image.tag; .style = "double")' > prod-validator-new.yaml
 
       - name: Commit prod version update
         run: |

--- a/pkg/helm/prod-validator.yaml
+++ b/pkg/helm/prod-validator.yaml
@@ -138,7 +138,6 @@ configmap:
   annotations: {}
   data:
     PROFILES_FILE: "/usr/local/data/profiles.json"
-    VERSION: "0.0.0"
 #---------------------------------------------
 
 #---------------------------------------------

--- a/pkg/helm/test-validator.yaml
+++ b/pkg/helm/test-validator.yaml
@@ -138,7 +138,6 @@ configmap:
   annotations: {}
   data:
     PROFILES_FILE: "/usr/local/data/profiles.json"
-    VERSION: "0.0.0"
 #---------------------------------------------
 
 #---------------------------------------------

--- a/pkg/scripts/act.sh
+++ b/pkg/scripts/act.sh
@@ -86,7 +86,6 @@ function release_event {
       .repository.name = \"$SERVICE_NAME\" | .repository.full_name = \"$DOCKER_REGISTRY_ACCOUNT/$SERVICE_NAME\" |
       .repository.owner.login = \"$DOCKER_REGISTRY_ACCOUNT\" | .release.body = \"Automated release of v$LATEST_TAG\" |
       .release.created_at = \"$TIMESTAMP\" | .release.published_at = \"$TIMESTAMP\" |
-      .configmap.data.VERSION = \"$LATEST_TAG\" |
       .release.prerelease = $PRERELEASE" testdata/release_event.json > "$EVENT_FILE"
 
   # Return the location of the newly created release_event.json


### PR DESCRIPTION
Two fixes (some of what has gone through in earlier test PRs):

1) Fix the committing of helm chart value files (the [switch](https://github.com/UCLALibrary/validation-service/blob/72ae94fd4e21dcf38c068e4d69910eda1c9c4462/.github/workflows/release.yml#L99) was causing the files not to be updated -- this has been fixed by using a temporary file (e.g., test-validator-new.yaml) that then gets copied to overwrite the one in the (e.g., test-validator) helm chart values file branch).

2) Once the update process was working I discovered the Docker image was missing the [VERSION env](https://github.com/UCLALibrary/validation-service/blob/72ae94fd4e21dcf38c068e4d69910eda1c9c4462/Dockerfile#L6), which was causing it to need to be set at runtime. So, I added that `arg` at the top of the Dockerfile, and so we can now remove the VERSION property from the Helm chart values file too now.

So, this cleanup PR removes VERSION from the runtime configurations (since it's now set as an ENV in the image itself).