### PR TITLE
[SERV-1248] Add Kakadu to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,17 @@ jobs:
 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Needed for accessing private repos
+
+    # Set up a two build strategy, one with Kakadu and one without
+    strategy:
+      matrix:
+        kakadu: ['Include Kakadu', 'Exclude Kakadu']
+      fail-fast: false
+
+    env:
+      KAKADU_VERSION: ${{ matrix.kakadu == 'Include Kakadu' && secrets.KAKADU_VERSION || '' }}
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -37,9 +48,9 @@ jobs:
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
           sh -s -- -b $(go env GOPATH)/bin ${{ env.GO_LINTER_VERSION }}
 
-    - name: Install oapi-codegen
+    - name: Install oapi-codegen # v2.4.1
       run: |
-        go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+        go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@9c09ef9e9d4be639bd3feff31ff2c06961421272
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -52,6 +63,20 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Configure Kakadu SSH key
+      if: env.ACT != 'true'
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.KAKADU_SSH_KEY }}" > ~/.ssh/kakadu_github_key
+        chmod 600 ~/.ssh/kakadu_github_key
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+        eval "$(ssh-agent -s)"
+        ssh-add ~/.ssh/kakadu_github_key
+        echo "Host github.com
+          IdentityFile ~/.ssh/kakadu_github_key
+          IdentitiesOnly yes
+          StrictHostKeyChecking accept-new" >> ~/.ssh/config
 
     # Build and test the application (also lints)
     - name: Build project

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,6 +14,15 @@ jobs:
   nightly:
     runs-on: ubuntu-latest
 
+    # Set up a two build strategy, one with Kakadu and one without
+    strategy:
+      matrix:
+        kakadu: ['Include Kakadu', 'Exclude Kakadu']
+      fail-fast: false
+
+    env:
+      KAKADU_VERSION: ${{ matrix.kakadu == 'Include Kakadu' && secrets.KAKADU_VERSION || '' }}
+
     steps:
     - name: Extract service name from repo name
       run: echo "SERVICE_NAME=$(echo '${{ github.repository }}' | cut -d'/' -f2)" >> $GITHUB_ENV
@@ -32,9 +41,9 @@ jobs:
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
           sh -s -- -b $(go env GOPATH)/bin ${{ env.GO_LINTER_VERSION }}
 
-    - name: Install oapi-codegen
+    - name: Install oapi-codegen # v2.4.1
       run: |
-        go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+        go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@9c09ef9e9d4be639bd3feff31ff2c06961421272
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -48,17 +57,22 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
+    - name: Configure Kakadu SSH key
+      if: env.ACT != 'true'
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.KAKADU_SSH_KEY }}" > ~/.ssh/kakadu_github_key
+        chmod 600 ~/.ssh/kakadu_github_key
+        ssh-keyscan github.com >> ~/.ssh/known_hosts
+        eval "$(ssh-agent -s)"
+        ssh-add ~/.ssh/kakadu_github_key
+        echo "Host github.com
+          IdentityFile ~/.ssh/kakadu_github_key
+          IdentitiesOnly yes
+          StrictHostKeyChecking accept-new" >> ~/.ssh/config
+
     # Build and test the application (also lints)
     - name: Build project
-      run: make all
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-      with:
-        context: .
-        file: ./Dockerfile
-        push: true
-        tags: ${{ env.DOCKER_REGISTRY_ACCOUNT }}/${{ env.SERVICE_NAME }}:nightly
-        build-args: |
-          SERVICE_NAME=${{ env.SERVICE_NAME }}
-          LOG_LEVEL=info
+      run: make all docker-push
+      env:
+        VERSION: nightly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,15 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    # Set up a two build strategy, one with Kakadu and one without
+    strategy:
+      matrix:
+        kakadu: ['Include Kakadu', 'Exclude Kakadu']
+      fail-fast: false
+
+    env:
+      KAKADU_VERSION: ${{ matrix.kakadu == 'Include Kakadu' && secrets.KAKADU_VERSION || '' }}
+
     steps:
       - name: Extract service name from repo name
         run: echo "SERVICE_NAME=$(echo '${{ github.repository }}' | cut -d'/' -f2)" >> $GITHUB_ENV
@@ -32,14 +41,13 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
             sh -s -- -b $(go env GOPATH)/bin ${{ env.GO_LINTER_VERSION }}
 
-      - name: Install yq
+      - name: Install yq # v4.45.1
         run: |
-          go install github.com/mikefarah/yq/v4@8bf425b4d1344db7cd469a8d10a390876e0c77fd # v4.45.1
+          go install github.com/mikefarah/yq/v4@8bf425b4d1344db7cd469a8d10a390876e0c77fd
 
-      - name: Install oapi-codegen
+      - name: Install oapi-codegen # v2.4.1
         run: |
           go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@9c09ef9e9d4be639bd3feff31ff2c06961421272
-          # v2.4.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
@@ -53,21 +61,25 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-        # Build and test the application (also lints)
-      - name: Build project
-        run: make all
+      - name: Configure Kakadu SSH key
+        if: env.ACT != 'true'
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.KAKADU_SSH_KEY }}" > ~/.ssh/kakadu_github_key
+          chmod 600 ~/.ssh/kakadu_github_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          ssh-add ~/.ssh/kakadu_github_key
+          echo "Host github.com
+            IdentityFile ~/.ssh/kakadu_github_key
+            IdentitiesOnly yes
+            StrictHostKeyChecking accept-new" >> ~/.ssh/config
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ env.DOCKER_REGISTRY_ACCOUNT }}/${{ env.SERVICE_NAME }}:${{ github.event.release.tag_name }}
-          build-args: |
-            SERVICE_NAME=${{ env.SERVICE_NAME }}
-            LOG_LEVEL=info
-            VERSION=${{ github.event.release.tag_name }}
+      # Build and test the application (also lints)
+      - name: Build project
+        run: make all docker-push
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
 
   # If a test deploy is desired, releases should first be run as pre-releases
   trigger-test-deploy:

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ profiles.json
 # Ignore GitHub Actions work products
 /test-validator.yaml
 /prod-validator.yaml
+
+# Kakadu private repository
+kakadu

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
 ##
-## Dockerfile for a UCLA Library microservice.
+## Dockerfile for a UCLA Library microservice that, optionally, includes Kakadu.
 ##
 
 ARG SERVICE_NAME
 ARG VERSION
 ARG LOG_LEVEL
 ARG HOST_DIR
+ARG ARCH
+ARG KAKADU_VERSION
 
 ##
-## STEP 1 - BUILD
+## STEP 1 - BUILD SERVICE
 ##
-FROM golang:1.24.2-alpine3.20 AS build
+FROM golang:1.24.2-alpine3.21 AS build
 
 # Inherit SERVICE_NAME arg and set as ENV
 ARG SERVICE_NAME
@@ -34,9 +36,34 @@ COPY . .
 RUN go build -o "/${SERVICE_NAME}"
 
 ##
-## STEP 2 - PACKAGE
+## STEP 2 - BUILD KAKADU
 ##
-FROM alpine:3.21
+FROM alpine:3.21.3 AS kakadu-build
+
+# Set variables for Kakadu
+ARG ARCH
+ARG KAKADU_VERSION
+
+ENV PATH=$PATH:"/opt/kakadu/${KAKADU_VERSION}/bin/Linux-${ARCH}-gcc"
+
+# Install curl to be used in container healthcheck
+RUN apk add --no-cache curl bash git gcc g++ make linux-headers musl-dev
+
+# Copy Kakadu from the builder stage to the final image
+COPY kakadu /opt/kakadu
+
+# Run `make` as part of the container build process to compile Kakadu, if needed
+RUN mkdir -p /opt/kdu/lib /opt/kdu/bin && \
+    if [ ! -z "$KAKADU_VERSION" ]; then \
+        cd /opt/kakadu/${KAKADU_VERSION}/make && make -f Makefile-Linux-${ARCH}-gcc all_but_jni_static; \
+        cp /opt/kakadu/${KAKADU_VERSION}/bin/Linux-${ARCH}-gcc/kdu_* /opt/kdu/bin/; \
+        cp /opt/kakadu/${KAKADU_VERSION}/lib/Linux-${ARCH}-gcc/*.a /opt/kdu/lib/; \
+    fi
+
+##
+## STEP 3 - PACKAGE
+##
+FROM alpine:3.21.3
 
 # Define the location of our application data directory
 ARG DATA_DIR="/usr/local/data"
@@ -58,34 +85,39 @@ ARG VERSION
 ENV VERSION=${VERSION}
 
 # Set the location of the profiles config
-ENV PROFILES_FILE="$DATA_DIR/profiles.json"
+ENV PROFILES_FILE="${DATA_DIR}/profiles.json"
 
-# Install curl to be used in container healthcheck
-RUN apk add --no-cache curl
+# Add an LD_LIBRARY_PATH for Kakadu libs
+ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 # Create a non-root user
 RUN addgroup -S "${SERVICE_NAME}" && adduser -S "${SERVICE_NAME}" -G "${SERVICE_NAME}"
 
-# Create a directory for our profiles file
-RUN mkdir -p "$DATA_DIR"
+# Create some required directory structures
+RUN mkdir -p "${DATA_DIR}/testdata" "${DATA_DIR}/html/assets"
 
 # Copy the templates directory into our container
-COPY "html/" "$DATA_DIR/html/"
+COPY "html/" "${DATA_DIR}/html/"
 
 # Copy files without --chown or --chmod (BuildKit not required)
+COPY "profiles.json" "${DATA_DIR}/"
+COPY "openapi.yml" "${DATA_DIR}/html/assets/"
 COPY --from=build "/${SERVICE_NAME}" "/sbin/${SERVICE_NAME}"
-COPY "profiles.json" "$PROFILES_FILE"
-COPY "openapi.yml" "$DATA_DIR/html/assets/"
+COPY --from=kakadu-build /opt/kdu/lib/ /usr/local/lib/
+COPY --from=kakadu-build /opt/kdu/bin/ /usr/local/bin/
 
 # Now, modify ownership and permissions in a separate RUN step
 RUN chown "${SERVICE_NAME}":"${SERVICE_NAME}" "/sbin/${SERVICE_NAME}" && chmod 0700 "/sbin/${SERVICE_NAME}"
-RUN chown -R "${SERVICE_NAME}:${SERVICE_NAME}" "$DATA_DIR" && chmod -R 0700 "$DATA_DIR"
+RUN chown -R "${SERVICE_NAME}:${SERVICE_NAME}" "${DATA_DIR}" && chmod -R 0700 "${DATA_DIR}"
 
 # Expose the port on which the application will run
 EXPOSE 8888
 
 # Create a non-root user
 USER "${SERVICE_NAME}"
+
+# Create a working directory
+WORKDIR "${DATA_DIR}"
 
 # Specify the command to be used when the image is used to start a container; use shell to support ENV name
 ENTRYPOINT [ "sh", "-c", "exec /sbin/${SERVICE_NAME}" ]

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ clone-kakadu: # Optionally, downloads Kakadu from its private git repo
 			exit 1; \
 		}; \
 	else \
-		@mkdir -p kakadu; \
+		mkdir -p kakadu; \
 		echo "[INFO] Kakadu is not included in build because KAKADU_VERSION is not set." >&2; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -48,30 +48,39 @@ docker-run: docker-build # Runs a Docker instance, independent of the tests
 	CONTAINER_ID=$(shell docker image ls -q --filter=reference=$(SERVICE_NAME)); \
 	docker run -p $(PORT):8888 --name $(SERVICE_NAME) \
 		-e LOG_LEVEL="$(LOG_LEVEL)" \
-		-v $(HOST_DIR):$(HOST_DIR) \
+		-v "$(HOST_DIR)":"$(HOST_DIR)" \
 		-d $$CONTAINER_ID
 
 docker-log: # Tails the logs of a container started with 'docker-run'
-	docker logs -f $(shell docker ps --filter "name=$(SERVICE_NAME)" --format "{{.ID}}")
+	@CONTAINER_ID=$$(docker ps --filter "name=$(SERVICE_NAME)" --format "{{.ID}}"); \
+	if [ -n "$$CONTAINER_ID" ]; then \
+		docker logs -f $$CONTAINER_ID; \
+	else \
+		echo "No running container named '$(SERVICE_NAME)' found."; \
+	fi
 
 docker-stop: # Stops a Docker container started with 'docker-run'
-	docker rm -f $(shell docker ps --filter "name=$(SERVICE_NAME)" --format "{{.ID}}")
+	@CONTAINER_ID=$$(docker ps -a --filter "name=$(SERVICE_NAME)" --format "{{.ID}}"); \
+	if [ -n "$$CONTAINER_ID" ]; then \
+		docker rm -f $$CONTAINER_ID; \
+	else \
+		echo "No container named '$(SERVICE_NAME)' found."; \
+	fi
 
 # 'docker-test' does not require 'docker-build', fwiw, 'docker-build' is just for debugging
 docker-test: clone-kakadu # Runs integration tests inside the Docker container
-	@mkdir -p kakadu
 	go test -tags=integration ./integration -v -args -service-name=$(SERVICE_NAME) -log-level=$(LOG_LEVEL) \
-		-host-dir=$(HOST_DIR)
+		-host-dir=$(HOST_DIR) -kakadu-version=$(KAKADU_VERSION) -arch=$(ARCH)
 
 docker-push: docker-build # Builds a Docker image and pushes it to DockerHub
-	LOWERCASED_ORG_NAME := $(shell echo $(ORG_NAME) | tr '[:upper:]' '[:lower:]')
-	@if [ -n "$(strip $(KAKADU_VERSION))" ]; then \
-		docker tag $(SERVICE_NAME):latest $(LOWERCASED_ORG_NAME)/$(SERVICE_NAME)-kakadu:$(VERSION); \
-		docker push docker.io/$(LOWERCASED_ORG_NAME)/$(SERVICE_NAME)-kakadu:$(VERSION); \
+	@LOWERCASED_ORG_NAME=$$(echo $(ORG_NAME) | tr '[:upper:]' '[:lower:]'); \
+	if [ -n "$(strip $(KAKADU_VERSION))" ]; then \
+		docker tag $(SERVICE_NAME):latest $$LOWERCASED_ORG_NAME/$(SERVICE_NAME)-kakadu:$(VERSION); \
+		docker push docker.io/$$LOWERCASED_ORG_NAME/$(SERVICE_NAME)-kakadu:$(VERSION); \
 	else \
-		docker tag $(SERVICE_NAME):latest $(LOWERCASED_ORG_NAME)/$(SERVICE_NAME):$(VERSION); \
-		docker push docker.io/$(LOWERCASED_ORG_NAME)/$(SERVICE_NAME):$(VERSION); \
-	fi \
+		docker tag $(SERVICE_NAME):latest $$LOWERCASED_ORG_NAME/$(SERVICE_NAME):$(VERSION); \
+		docker push docker.io/$$LOWERCASED_ORG_NAME/$(SERVICE_NAME):$(VERSION); \
+	fi
 
 clean: # Cleans up all artifacts created by the build
 	rm -rf $(SERVICE_NAME) api/api.go
@@ -90,11 +99,11 @@ ci-run: config api # Runs CI locally using ACT (which must be installed)
 
 clone-kakadu: # Optionally, downloads Kakadu from its private git repo
 	@if [ ! -d kakadu/.git ] && [ -n "$(strip $(KAKADU_VERSION))" ]; then \
-		echo "Pulling the latest version of Kakadu into the container"; \
+		echo "[INFO] Pulling the latest version of Kakadu into the container"; \
 		rm -rf kakadu; \
 		if [ -n "$$PERSONAL_ACCESS_TOKEN" ]; then \
 			git clone --depth 1 --filter=blob:none --sparse \
-				https://x-access-token:$$PERSONAL_ACCESS_TOKEN@github.com/$(ORG_NAME)/kakadu.git kakadu; \
+				"https://x-access-token:$$PERSONAL_ACCESS_TOKEN@github.com/$(ORG_NAME)/kakadu.git kakadu"; \
 		else \
 			git clone --depth 1 --filter=blob:none --sparse git@github.com:$(ORG_NAME)/kakadu.git kakadu; \
   		fi; \
@@ -104,14 +113,15 @@ clone-kakadu: # Optionally, downloads Kakadu from its private git repo
 			exit 1; \
 		}; \
 	elif [ -d kakadu/.git ] && [ -n "$(strip $(KAKADU_VERSION))" ]; then \
-		echo "Kakadu already cloned. Pulling latest changes..." >&2; \
+		echo "[INFO] Kakadu already cloned. Pulling latest changes..." >&2; \
 		cd kakadu && \
 		git pull origin $$(git symbolic-ref --short HEAD) || { \
 			echo "Error: Failed to pull latest changes for Kakadu" >&2; \
 			exit 1; \
 		}; \
 	else \
-		echo "Kakadu is not included in build because KAKADU_VERSION is not set." >&2; \
+		@mkdir -p kakadu; \
+		echo "[INFO] Kakadu is not included in build because KAKADU_VERSION is not set." >&2; \
 	fi
 
 help: # Outputs information about the build's available targets

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,12 @@ clone-kakadu: # Optionally, downloads Kakadu from its private git repo
 	@if [ ! -d kakadu/.git ] && [ -n "$(strip $(KAKADU_VERSION))" ]; then \
 		echo "Pulling the latest version of Kakadu into the container"; \
 		rm -rf kakadu; \
-		git clone --depth 1 --filter=blob:none --sparse git@github.com:$(ORG_NAME)/kakadu.git kakadu; \
+		if [ -n "$$PERSONAL_ACCESS_TOKEN" ]; then \
+			git clone --depth 1 --filter=blob:none --sparse \
+				https://x-access-token:$$PERSONAL_ACCESS_TOKEN@github.com/$(ORG_NAME)/kakadu.git kakadu; \
+		else \
+			git clone --depth 1 --filter=blob:none --sparse git@github.com:$(ORG_NAME)/kakadu.git kakadu; \
+  		fi; \
 		cd kakadu && \
 		git sparse-checkout set $(KAKADU_VERSION) || { \
 			echo "Error: Failed to clone sparse Kakadu" >&2; \

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,13 @@
 SERVICE_NAME := validation-service
 LOG_LEVEL := info
 PORT := 8888
-VERSION := dev-SNAPSHOT
 HOST_DIR := $(shell pwd)/testdata
+
+# Overrideable variables that also take ENV into consideration
+ARCH ?= x86-64
+KAKADU_VERSION ?= ""
+VERSION ?= dev-SNAPSHOT
+ORG_NAME ?= UCLALibrary
 
 # Force the API target to run even if the openapi.yml has not been touched/changed
 ifneq ($(filter FORCE,$(MAKECMDGOALS)),)
@@ -34,9 +39,10 @@ build: api # Compiles the project's Go code into an executable
 test: # Runs the unit tests (integration tests are excluded)
 	go test -tags=unit ./... -v -args -log-level=$(LOG_LEVEL) -host-dir=$(HOST_DIR)
 
-docker-build: # Builds a Docker container for manual testing
+docker-build: clone-kakadu  # Builds a Docker container for manual testing
 	docker build . --tag $(SERVICE_NAME) --build-arg SERVICE_NAME=$(SERVICE_NAME) \
-		--build-arg VERSION=$(VERSION) --build-arg HOST_DIR=$(HOST_DIR)
+		--build-arg VERSION=$(VERSION) --build-arg HOST_DIR=$(HOST_DIR) \
+		--build-arg KAKADU_VERSION=$(KAKADU_VERSION) --build-arg ARCH=$(ARCH) \
 
 docker-run: docker-build # Runs a Docker instance, independent of the tests
 	CONTAINER_ID=$(shell docker image ls -q --filter=reference=$(SERVICE_NAME)); \
@@ -52,9 +58,20 @@ docker-stop: # Stops a Docker container started with 'docker-run'
 	docker rm -f $(shell docker ps --filter "name=$(SERVICE_NAME)" --format "{{.ID}}")
 
 # 'docker-test' does not require 'docker-build', fwiw, 'docker-build' is just for debugging
-docker-test: # Runs integration tests inside the Docker container
+docker-test: clone-kakadu # Runs integration tests inside the Docker container
+	@mkdir -p kakadu
 	go test -tags=integration ./integration -v -args -service-name=$(SERVICE_NAME) -log-level=$(LOG_LEVEL) \
 		-host-dir=$(HOST_DIR)
+
+docker-push: docker-build # Builds a Docker image and pushes it to DockerHub
+	LOWERCASED_ORG_NAME := $(shell echo $(ORG_NAME) | tr '[:upper:]' '[:lower:]')
+	@if [ -n "$(strip $(KAKADU_VERSION))" ]; then \
+		docker tag $(SERVICE_NAME):latest $(LOWERCASED_ORG_NAME)/$(SERVICE_NAME)-kakadu:$(VERSION); \
+		docker push docker.io/$(LOWERCASED_ORG_NAME)/$(SERVICE_NAME)-kakadu:$(VERSION); \
+	else \
+		docker tag $(SERVICE_NAME):latest $(LOWERCASED_ORG_NAME)/$(SERVICE_NAME):$(VERSION); \
+		docker push docker.io/$(LOWERCASED_ORG_NAME)/$(SERVICE_NAME):$(VERSION); \
+	fi \
 
 clean: # Cleans up all artifacts created by the build
 	rm -rf $(SERVICE_NAME) api/api.go
@@ -70,6 +87,27 @@ run: config api build # Runs service locally, independent of Docker
 
 ci-run: config api # Runs CI locally using ACT (which must be installed)
 	pkg/scripts/act.sh $(JOB) $(SERVICE_NAME)
+
+clone-kakadu: # Optionally, downloads Kakadu from its private git repo
+	@if [ ! -d kakadu/.git ] && [ -n "$(strip $(KAKADU_VERSION))" ]; then \
+		echo "Pulling the latest version of Kakadu into the container"; \
+		rm -rf kakadu; \
+		git clone --depth 1 --filter=blob:none --sparse git@github.com:$(ORG_NAME)/kakadu.git kakadu; \
+		cd kakadu && \
+		git sparse-checkout set $(KAKADU_VERSION) || { \
+			echo "Error: Failed to clone sparse Kakadu" >&2; \
+			exit 1; \
+		}; \
+	elif [ -d kakadu/.git ] && [ -n "$(strip $(KAKADU_VERSION))" ]; then \
+		echo "Kakadu already cloned. Pulling latest changes..." >&2; \
+		cd kakadu && \
+		git pull origin $$(git symbolic-ref --short HEAD) || { \
+			echo "Error: Failed to pull latest changes for Kakadu" >&2; \
+			exit 1; \
+		}; \
+	else \
+		echo "Kakadu is not included in build because KAKADU_VERSION is not set." >&2; \
+	fi
 
 help: # Outputs information about the build's available targets
 	@awk -F ':.*?# ' '/^[a-z0-9_-]+:.*?# / && $$1 !~ /[A-Z.]/ { \

--- a/README.md
+++ b/README.md
@@ -97,8 +97,47 @@ To stop the Docker container when you are done with it:
 
     make docker-stop
 
-Note: None of the Docker specific Makefile targets (except `docker-test`) are required to build or test the project.
+To build and push a container to DockerHub, use:
+
+    make docker-push
+
+Note: None of the Dockers specific Makefile targets (except `docker-test`) are required to build or test the project.
 They are just additional conveniences for developers.
+
+## Including Kakadu in Your Build
+
+Kakadu is a JPEG-2000 library that supports working with JP2 and JPX images. It is proprietary software, so cannot be
+redistributed by us, but if you have a license there is a way to incorporate it into this build. To start, you'd need
+to store the Kakadu source code in a 'kakadu' GitHub repository in your organization. Once you've done that, you need
+to ensure that any users running this build have permission to access that private repo. These users will also need to
+use the SSH method of connecting to GitHub (instead of the HTTPS method).
+
+If you want to confirm that the above is set up correctly, there is a Makefile target that will allow you to clone your
+organization's 'kakadu' repository to your local machine:
+
+    ORG_NAME=uclalibrary KAKADU_VERSION=v8_4_1-12345L make clone-kakadu
+
+You would, of course, replace `uclalibrary` with your organization's name and use your organization's `KAKADU_VERSION`,
+which includes a number unique to your license. If you're going to push Docker images to DockerHub, it is assumed that
+your organization has the same name there. The form of the name must also be lowercase. GitHub is not picky about that,
+but DockerHub is.
+
+Running `clone-kakadu` will create a 'kakadu' directory in your project. Don't worry about it getting checked into Git.
+We have added that directory to the project's `.gitignore` file. If you'd like to use Kakadu in the build, you'll need
+an additional Makefile target: `docker-build` (or `docker-push` for building and pushing up to DockerHub). If you do not
+work at UCLA, you'll still need to supply `ORG_NAME` and `KAKADU_VERSION` as ENV properties. If you do work at UCLA,
+`KAKADU_VERSION` is the only property you'll need -- check the UCLALibrary 'kakadu' repo for the actual version number).
+A UCLA person should be able to build the container using:
+
+    KAKADU_VERSION=v8_4_1-12345L make docker-build
+
+New releases should be done through the GitHub Actions interface, but it is also possible to push a version to DockerHub
+from a local developer's machine, too:
+
+    KAKADU_VERSION=v8_4_1-12345L make docker-push
+
+Note: this will build the Docker container before pushing it to DockerHub, and it will require the developer running the
+Makefile target to be logged into DockerHub on their local machine.
 
 ## Building and Deploying with ACT
 

--- a/README.md
+++ b/README.md
@@ -115,12 +115,10 @@ use the SSH method of connecting to GitHub (instead of the HTTPS method).
 If you want to confirm that the above is set up correctly, there is a Makefile target that will allow you to clone your
 organization's 'kakadu' repository to your local machine:
 
-    ORG_NAME=uclalibrary KAKADU_VERSION=v8_4_1-12345L make clone-kakadu
+    ORG_NAME=UCLALibrary KAKADU_VERSION=v8_4_1-12345L make clone-kakadu
 
-You would, of course, replace `uclalibrary` with your organization's name and use your organization's `KAKADU_VERSION`,
-which includes a number unique to your license. If you're going to push Docker images to DockerHub, it is assumed that
-your organization has the same name there. The form of the name must also be lowercase. GitHub is not picky about that,
-but DockerHub is.
+You would, of course, replace `UCLALibrary` with your organization's name and use your organization's `KAKADU_VERSION`,
+which includes a number unique to your license.
 
 Running `clone-kakadu` will create a 'kakadu' directory in your project. Don't worry about it getting checked into Git.
 We have added that directory to the project's `.gitignore` file. If you'd like to use Kakadu in the build, you'll need
@@ -137,7 +135,10 @@ from a local developer's machine, too:
     KAKADU_VERSION=v8_4_1-12345L make docker-push
 
 Note: this will build the Docker container before pushing it to DockerHub, and it will require the developer running the
-Makefile target to be logged into DockerHub on their local machine.
+Makefile target to be logged into DockerHub on their local machine. In addition, if you use HTTPS instead of SSH to
+connect to GitHub, you'll also need to create a `PERSONAL_ACCESS_TOKEN` and set that property name and its value in your
+local system's environment. If you have a `PERSONAL_ACCESS_TOKEN` set in your environment, the build scripts will try to
+use that and an HTTPS connection to GitHub instead of the default SSH connection.
 
 ## Building and Deploying with ACT
 

--- a/integration/assets_test.go
+++ b/integration/assets_test.go
@@ -1,5 +1,8 @@
 //go:build integration
 
+// Package integration holds the project's integration tests.
+//
+// This file tests the assets are available as expected.
 package integration
 
 import (

--- a/integration/kakadu_test.go
+++ b/integration/kakadu_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+// Package integration holds the project's integration tests.
+//
+// This file tests that Kakadu has been installed and is functioning as expected.
+package integration
+
+import (
+	"bytes"
+	docker "context"
+	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestKakaduInstallation checks if Kakadu is installed in the container and functioning as expected.
+func TestKakaduInstallation(t *testing.T) {
+	if os.Getenv("KAKADU_VERSION") == "" {
+		t.Skip("Skipping Kakadu integration test: KAKADU_VERSION is not set")
+	}
+
+	context := docker.Background()
+	_, reader, err := container.Exec(context, []string{"kdu_compress", "-v"})
+	if err != nil {
+		t.Fatalf("Failed to execute command inside container: %v", err)
+	}
+
+	// Separate stdout and stderr from the raw reader
+	var stdout, stderr bytes.Buffer
+	_, err = stdcopy.StdCopy(&stdout, &stderr, reader)
+	if err != nil {
+		t.Fatalf("Failed to read container output: %v", err)
+	}
+
+	value := strings.TrimSpace(stdout.String())
+	assert.True(t, strings.HasPrefix(value, "This is Kakadu"), "Expected output: 'This is Kakadu'")
+}

--- a/pkg/helm/prod-validator.yaml
+++ b/pkg/helm/prod-validator.yaml
@@ -66,7 +66,7 @@ replicaCount: 1
 imagePullSecrets:
   - name: prod-validator-dockerhub-secret
 image:
-  repository: uclalibrary/validation-service
+  repository: uclalibrary/validation-service-kakadu
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.0.0"

--- a/pkg/helm/test-validator.yaml
+++ b/pkg/helm/test-validator.yaml
@@ -66,7 +66,7 @@ replicaCount: 1
 imagePullSecrets:
   - name: test-validator-dockerhub-secret
 image:
-  repository: uclalibrary/validation-service
+  repository: uclalibrary/validation-service-kakadu
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: "0.0.0"

--- a/pkg/utils/flags.go
+++ b/pkg/utils/flags.go
@@ -11,15 +11,19 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-var ServiceName string // The name of the Web service we're building, running, and testing
-var LogLevel string    // The desired log level at which the Web service should be run
-var HostDir string     // The location of the mounted host directory (contains resource files)
+var ServiceName string   // The name of the Web service we're building, running, and testing
+var LogLevel string      // The desired log level at which the Web service should be run
+var HostDir string       // The location of the mounted host directory (contains resource files)
+var KakaduVersion string // The version of Kakadu that's being used (this may also be empty if Kakadu isn't used)
+var BuildArch string     // The system architecture that's going to run the Kakadu build (default is usually fine)
 
 // init initializes the flags that have been defined
 func init() {
 	flag.StringVar(&ServiceName, "service-name", "service", "Name of service being tested")
 	flag.StringVar(&LogLevel, "log-level", "info", "Log level (debug, info, warn, error)")
 	flag.StringVar(&HostDir, "host-dir", "", "HOST_DIR env variable that is copied into test-container")
+	flag.StringVar(&KakaduVersion, "kakadu-version", "", "The version of Kakadu being used")
+	flag.StringVar(&BuildArch, "arch", "x86-64", "The system architecture of the Kakadu build")
 }
 
 // GetLogLevel gets the current log level as a zapcore.Level.


### PR DESCRIPTION
* Add Kakadu (as an option) to the build
  * Update Makefile
  * Update GitHub Actions
  * Update Dockerfile
  * Update build args and build ENV
* Add integration test that confirms Kakadu is installed in container and properly linked
* Update README with new details about Kakadu
* Renamed Docker repo `validation-service-ucla` to `validation-service-kakadu` to make it more generic