### PR TITLE
Update release.yml to allow empty commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,11 +90,6 @@ jobs:
       contents: write
 
     steps:
-      # We don't allow empties in GitHub Actions because it might conceal problems
-      - name: Set EMPTY_ALLOWED ENV if running in ACT
-        if: env.ACT == 'true'
-        run: echo "EMPTY_ALLOWED=--allow-empty" >> $GITHUB_ENV
-
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -117,7 +112,7 @@ jobs:
           git config --global user.email "softwaredev-services@library.ucla.edu"
           git config --global user.name "ServicesBot"
           git add test-validator.yaml
-          git commit --no-verify $EMPTY_ALLOWED -m "Automated update of test Docker image tag"
+          git commit --no-verify --allow-empty -m "Automated update of test Docker image tag"
           git push
 
   # If release is run without the pre-release checkbox checked, it's the production release
@@ -129,11 +124,6 @@ jobs:
       contents: write
 
     steps:
-      # We don't allow empties in GitHub Actions because it might conceal problems
-      - name: Set EMPTY_ALLOWED ENV if running in ACT
-        if: env.ACT == 'true'
-        run: echo "EMPTY_ALLOWED=--allow-empty" >> $GITHUB_ENV
-
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -156,5 +146,5 @@ jobs:
           git config --global user.email "softwaredev-services@library.ucla.edu"
           git config --global user.name "ServicesBot"
           git add prod-validator.yaml
-          git commit --no-verify $EMPTY_ALLOWED -m "Automated update of prod Docker image tag"
+          git commit --no-verify --allow-empty -m "Automated update of prod Docker image tag"
           git push


### PR DESCRIPTION
Some use cases will require this on GitHub Actions. We'd previously only allowed on ACT.