### PR TITLE
[SERV-1265] Add Kakadu support to ACT build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Docker Image
 
 # Defines environmental variables
 env:
-  GO_VERSION: '1.24.0'
+  GO_VERSION: '1.24.2'
   GO_LINTER_VERSION: 'v1.64.6'
 
 # Controls when the action will run
@@ -64,11 +64,21 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Configure Kakadu SSH key
+    - name: Import Kakadu SSH key on GitHub
       if: env.ACT != 'true'
       run: |
         mkdir -p ~/.ssh
         echo "${{ secrets.KAKADU_SSH_KEY }}" > ~/.ssh/kakadu_github_key
+
+    # On ACT, we encode the SSH key using Base64 so it can be passed on the command line
+    - name: Import Kakadu SSH key while running in ACT
+      if: env.ACT == 'true'
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.SSH_PRIVATE_KEY_B64 }}" | base64 -d > ~/.ssh/kakadu_github_key
+
+    - name: Configure Kakadu SSH key
+      run: |
         chmod 600 ~/.ssh/kakadu_github_key
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         eval "$(ssh-agent -s)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,19 +65,20 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Import Kakadu SSH key on GitHub
-      if: env.ACT != 'true'
+      if: env.KAKADU_VERSION != '' && env.ACT != 'true'
       run: |
         mkdir -p ~/.ssh
         echo "${{ secrets.KAKADU_SSH_KEY }}" > ~/.ssh/kakadu_github_key
 
     # On ACT, we encode the SSH key using Base64 so it can be passed on the command line
     - name: Import Kakadu SSH key while running in ACT
-      if: env.ACT == 'true'
+      if: env.KAKADU_VERSION != '' && env.ACT == 'true'
       run: |
         mkdir -p ~/.ssh
         echo "${{ secrets.SSH_PRIVATE_KEY_B64 }}" | base64 -d > ~/.ssh/kakadu_github_key
 
     - name: Configure Kakadu SSH key
+      if: env.KAKADU_VERSION != ''
       run: |
         chmod 600 ~/.ssh/kakadu_github_key
         ssh-keyscan github.com >> ~/.ssh/known_hosts

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 name: Build and Publish Snapshot
 
 env:
-  GO_VERSION: '1.24.0'
+  GO_VERSION: '1.24.2'
   GO_LINTER_VERSION: 'v1.64.6'
   DOCKER_REGISTRY_ACCOUNT: ${{ vars.DOCKER_REGISTRY_ACCOUNT }}
 
@@ -57,11 +57,21 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Configure Kakadu SSH key
+    - name: Import Kakadu SSH key on GitHub
       if: env.ACT != 'true'
       run: |
         mkdir -p ~/.ssh
         echo "${{ secrets.KAKADU_SSH_KEY }}" > ~/.ssh/kakadu_github_key
+
+      # On ACT, we encode the SSH key using Base64 so it can be passed on the command line
+    - name: Import Kakadu SSH key while running in ACT
+      if: env.ACT == 'true'
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.SSH_PRIVATE_KEY_B64 }}" | base64 -d > ~/.ssh/kakadu_github_key
+
+    - name: Configure Kakadu SSH key
+      run: |
         chmod 600 ~/.ssh/kakadu_github_key
         ssh-keyscan github.com >> ~/.ssh/known_hosts
         eval "$(ssh-agent -s)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Build and Publish Release
 
 env:
-  GO_VERSION: '1.24.0'
+  GO_VERSION: '1.24.1'
   GO_LINTER_VERSION: 'v1.64.6'
   DOCKER_REGISTRY_ACCOUNT: ${{ vars.DOCKER_REGISTRY_ACCOUNT }}
 
@@ -61,11 +61,21 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Configure Kakadu SSH key
+      - name: Import Kakadu SSH key on GitHub
         if: env.ACT != 'true'
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.KAKADU_SSH_KEY }}" > ~/.ssh/kakadu_github_key
+
+        # On ACT, we encode the SSH key using Base64 so it can be passed on the command line
+      - name: Import Kakadu SSH key while running in ACT
+        if: env.ACT == 'true'
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY_B64 }}" | base64 -d > ~/.ssh/kakadu_github_key
+
+      - name: Configure Kakadu SSH key
+        run: |
           chmod 600 ~/.ssh/kakadu_github_key
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           eval "$(ssh-agent -s)"

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ run: config api build # Runs service locally, independent of Docker
 	PROFILES_FILE="profiles.json" LOG_LEVEL=$(LOG_LEVEL) VERSION=$(VERSION) HOST_DIR=$(HOST_DIR) ./$(SERVICE_NAME)
 
 ci-run: config api # Runs CI locally using ACT (which must be installed)
-	pkg/scripts/act.sh $(JOB) $(SERVICE_NAME)
+	pkg/scripts/act.sh $(JOB) $(SERVICE_NAME) $(KAKADU_VERSION)
 
 clone-kakadu: # Optionally, downloads Kakadu from its private git repo
 	@if [ ! -d kakadu/.git ] && [ -n "$(strip $(KAKADU_VERSION))" ]; then \

--- a/README.md
+++ b/README.md
@@ -186,13 +186,13 @@ Below are examples of how each workflow can be run (note the required `JOB=` pre
 It is also possible to run ACT while supplying a Kakadu version (causing Kakadu to be installed into the validation
 service container). This option would look like:
 
-    KAKADU_VERSION=v8_4_1-12345L make ci-run JOB=build
+    make ci-run JOB=build KAKADU_VERSION=v8_4_1-12345L
 
-    KAKADU_VERSION=v8_4_1-12345L make ci-run JOB=nightly
+    make ci-run JOB=nightly KAKADU_VERSION=v8_4_1-12345L
 
-    KAKADU_VERSION=v8_4_1-12345L make ci-run JOB=prerelease
+    make ci-run JOB=prerelease KAKADU_VERSION=v8_4_1-12345L
 
-    KAKADU_VERSION=v8_4_1-12345L make ci-run JOB=release
+    make ci-run JOB=release KAKADU_VERSION=v8_4_1-12345L
 
 In order for this to work, you must have the SSH private key that works with your `kakadu` GitHub repo in a file at:
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ Below are examples of how each workflow can be run (note the required `JOB=` pre
 
     make ci-run JOB=release
 
+It is also possible to run ACT while supplying a Kakadu version (causing Kakadu to be installed into the validation
+service container). This option would look like:
+
+    KAKADU_VERSION=v8_4_1-12345L make ci-run JOB=build
+
+    KAKADU_VERSION=v8_4_1-12345L make ci-run JOB=nightly
+
+    KAKADU_VERSION=v8_4_1-12345L make ci-run JOB=prerelease
+
+    KAKADU_VERSION=v8_4_1-12345L make ci-run JOB=release
+
+In order for this to work, you must have the SSH private key that works with your `kakadu` GitHub repo in a file at:
+
+    ~/.ssh/kakadu_github_key
+
+That's where our [script](pkg/scripts/act.sh) that runs ACT expects to find it.
+
 This functionality is probably most just useful for UCLA Library folks, but it's documented here in case others are
 interested in running this on their own, too.
 


### PR DESCRIPTION
* Update Go version in GitHub Actions
* Update GitHub Actions to handle Kakadu SSH key differently from ACT
* Update README to document Kakadu inclusion in ACT builds
* Update act.sh to include Kakadu is its version is supplied at runtime